### PR TITLE
Added clear method for path prefix.

### DIFF
--- a/src/main/java/de/leonhard/storage/internal/FlatFile.java
+++ b/src/main/java/de/leonhard/storage/internal/FlatFile.java
@@ -311,6 +311,10 @@ public abstract class FlatFile implements DataStorage, Comparable<FlatFile> {
     write();
   }
 
+  public final void clearPathPrefix() {
+    this.pathPrefix = null;
+  }
+
   // ----------------------------------------------------------------------------------------------------
   // Internal stuff
   // ----------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Hello ! 

I've just added a method to clear the path prefix that, I think, is better than just calling setPathPrefix(null). (Discussed with Leonhard in an issue)

I've been using this lib for a few months and I'm planning to use it everywhere since it's really useful compared to the basic
vanilla spigot configuration framework!